### PR TITLE
rm -rf for windows

### DIFF
--- a/test_model.py
+++ b/test_model.py
@@ -6,7 +6,6 @@ import os
 import cv2
 import numpy as np
 from PIL import Image
-from scipy.misc import imresize as imresize
 
 import torch
 import torchvision.models as models

--- a/utils.py
+++ b/utils.py
@@ -33,7 +33,10 @@ def extract_frames(video_file, num_frames=8):
     frame_paths = sorted([os.path.join('frames', frame)
                           for frame in os.listdir('frames')])
     frames = load_frames(frame_paths, num_frames=num_frames)
-    subprocess.call(['rm', '-rf', 'frames'])
+    for f in os.listdir('frames'):
+        os.remove('frames/'+f)
+    os.rmdir('frames')
+    # subprocess.call(['rm', '-rf', 'frames'])
     return frames
 
 


### PR DESCRIPTION
use os.remove and os.rmdir instead of calling system rm -rf which is not available on Windows 